### PR TITLE
Nehreen/initiating-testing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,18 +1,24 @@
 {
 	"presets": [
-	  [
-		"@babel/preset-env",
-		{
-		  "modules": false
-		}
-	  ],
-	  "@babel/preset-react"
+		[
+			"@babel/preset-env",
+			{
+				// need the following code to avoid the import regenerator-runtime/runtime issue
+				"targets": {
+					"node": "current" // the target node version, boolean true, or "current".
+				}
+			}
+		],
+		"@babel/preset-react"
 	],
-	"plugins": [["@babel/plugin-transform-runtime", 
-	{
-		"helpers": true,
-		"regenerator": true
-	}], 
+	"plugins": [
+		[
+			"@babel/plugin-transform-runtime",
+			{
+				"helpers": true,
+				"regenerator": true
+			}
+		],
 		["@babel/plugin-transform-async-to-generator"]
-		]
-  }
+	]
+}

--- a/__test__/backend/jest-setup.js
+++ b/__test__/backend/jest-setup.js
@@ -1,5 +1,5 @@
 // const regeneratorRuntime = require('regenerator-runtime');
-import 'regenerator-runtime/runtime';
+// import 'regenerator-runtime/runtime';
 
 module.exports = () => {
   global.testServer = require('../../server/server.js');

--- a/__test__/backend/jest-teardown.js
+++ b/__test__/backend/jest-teardown.js
@@ -1,6 +1,5 @@
-// import regeneratorRuntime from 'regenerator-runtime';
-
+// import 'regenerator-runtime';
 
 module.exports = async (globalConfig) => {
-  global.testServer.close();
+	global.testServer.close();
 };

--- a/server/server.js
+++ b/server/server.js
@@ -16,14 +16,16 @@ const userRouter = require('./routers/userRouter.js');
 const awsRouter = require('./routers/aws.js');
 
 app.use('/secret', (req, res) => {
-  return res.status(200).send('Made it to secret page!');
-})
+	return res.status(200).send('Made it to secret page!');
+});
 
 app.use('/aws', awsRouter);
 app.use('/user', userRouter);
 
 app.use('*', (req, res) => {
-	return res.status(404).json({ err: 'endpoint requested is not found' });
+	return res
+		.status(404)
+		.json({ err: 'endpoint requested is not found' });
 });
 
 app.use((err, req, res, next) => {
@@ -40,6 +42,8 @@ app.use((err, req, res, next) => {
 	return res.status(errorObj.status).json(errorObj.message);
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
 	console.log('Listening on port ' + PORT);
 });
+
+module.exports = server;


### PR DESCRIPTION
if approved, this will:
- allow us to use async/await keywords with jest
- specify which version of node for babel to work with
- export app.listen in the server file as its own modular code so that jest teardown can work correctly